### PR TITLE
Fix tasks path error in Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - ansible-playbook -i tests/inventory tests/test_travis.yml --syntax-check
 
   # Run linter on role
-  - ansible-lint task/main.yml
+  - ansible-lint tasks/main.yml
 
   # Run filter plugins tests
   - py.test -v


### PR DESCRIPTION
Due to a template error, see infOpen/cookiecutter-ansible-role/pull/16